### PR TITLE
Dockerfile Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-buster AS builder
+# Builder stage dependencies aren't needed by the app at runtime
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    gcc
+COPY requirements.txt .
+RUN pip install --upgrade pip setuptools wheel
+RUN pip install -r requirements.txt
 
+FROM python:3.8-slim-buster AS app
 WORKDIR /app
-
-RUN apt-get update \
-    && apt-get -y install libpq-dev gcc
-
-COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
-
+RUN apt-get update && apt-get install -y libpq5 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local /usr/local/
 COPY . .
-
-CMD ["/bin/bash","run.sh"]
+CMD ["/bin/bash", "run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM python:3.8-slim-buster
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get -y install libpq-dev gcc \
-    && pip3 install psycopg2
+    && apt-get -y install libpq-dev gcc
 
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
- Removed Dockerfile command to install the latest version of psycopg2 since requirements.txt specifies 2.8.6
- Reduced built docker images size by roughly 40% (135MB) by using multistage build so build deps arent distributed for runtime